### PR TITLE
Prevent noninteractive builds from requiring input

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+
+libpam-radius-auth (1.5.0-cl3u2) RELEASED; urgency=low
+
+  * Disable pam authentication requirement for chsh during postinst
+
+ -- Boris Lukashev <rageltman@sempervictus.com>  Sun, 2 Aug 2020 14:50:30 -0400
+
 libpam-radius-auth (1.5.0-cl3u1) RELEASED; urgency=low
   * New Enabled - When the Vendor Specific Option (VSA) containing
     shell:priv-lvl is present and and the level value is >= to the level

--- a/debian/radius-shell.postinst
+++ b/debian/radius-shell.postinst
@@ -11,6 +11,8 @@ case "$1" in
         chmod 750 $radshell
         chgrp users $radshell
         setcap  cap_setuid+ep $radshell
+        # Temporarily comment password entry requirement from PAM configuration
+        sed -i 's|auth       required   pam_shells.so|#auth       required   pam_shells.so|' /etc/pam.d/chsh
         # The users will have been created by the libnss-mapuser package
         # and possibly by an older version, so change the shells here.
         # This also prevents a loop in package install ordering dependencies
@@ -22,6 +24,8 @@ case "$1" in
                 *) chsh -s $radshell $usr ;;
             esac
         done
+        # Restore PAM configuration
+        sed -i 's|#auth       required   pam_shells.so|auth       required   pam_shells.so|' /etc/pam.d/chsh
         ;;
 esac
 


### PR DESCRIPTION
The radius-shell package deployment can fail during a Jenkins
build because the non-interactive process is prompted for passwd
entry during chsh call:
```
Setting up radius-shell (1.5.0-cl3u1) ...
Password: chsh: PAM: Authentication failure
dpkg: error processing package radius-shell (--configure):
```
Comment 'auth       required   pam_shells.so' directive in the
chsh pam.d configuration while running the radius-shell postinst
script, restoring contents after completing the loop calling chsh.