### PR TITLE
PAM: T4943: Replaced shell from bash to vbash

### DIFF
--- a/src/radius_shell.c
+++ b/src/radius_shell.c
@@ -112,11 +112,11 @@ execit:
 	/* should really check this against /etc/shell */
 	snprintf(execshell, sizeof execshell, "/bin/%s", check);
 #else
-	check = "bash";
+	check = "vbash";
 	if (*args[0] == '-')
-		shell = "-bash";
+		shell = "-vbash";
 	else
-		shell = "bash";
+		shell = "vbash";
 	snprintf(execshell, sizeof execshell, "/bin/%s", check);
 #endif
 


### PR DESCRIPTION
This change was lost after cf571ca6c722d3d2b0c359dddf835a3f406b194b