### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ VyOS fork of the upstream `pam_radius_auth` PAM module — turns any host into a
 ## Build / test / run
 
 ```sh
+autoreconf -i           # generate ./configure from configure.ac
 ./configure
 make
 dpkg-buildpackage -us -uc # produces vyos-libpam-radius-auth + vyos-radius-shell .debs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,3 @@ Mirror twin: `VyOS-Networks/libpam-radius-auth`. Canonical side is here. Active 
 
 - Renamed source/binary packages (`vyos-libpam-radius-auth`, `vyos-radius-shell`) on purpose — do not revert to upstream `libpam-radius-auth` package names without a coordinated change in `vyos-build-packages` and `vyos-1x` PAM templates.
 - The `Jenkinsfile` is upstream cruft; VyOS CI runs through GitHub Actions reusables in `vyos/.github`.
-
----
-
-This file is mirrored on Confluence: [`vyos/libpam-radius-auth`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818479352). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+## Project purpose
+
+VyOS fork of the upstream `pam_radius_auth` PAM module — turns any host into a RADIUS client for authentication, password change, and (Linux-only) session accounting. Ships as the Debian source package `vyos-libpam-radius-auth`, plus a `vyos-radius-shell` companion package (shell front-end for RADIUS users).
+
+## Tech stack
+
+- C, GNU autotools (`configure.ac`, `Makefile`, `acinclude.m4`, `m4/`).
+- Debian packaging in `debian/` (debhelper >= 12, `libpam0g-dev`, `libaudit-dev`, `libcap-dev`).
+- License: GPL-2.0 (per `LICENSE`).
+
+## Build / test / run
+
+```sh
+./configure
+make
+dpkg-buildpackage -us -uc # produces vyos-libpam-radius-auth + vyos-radius-shell .debs
+```
+
+No in-tree test runner. Configuration lives at `pam_radius_auth.conf`; man pages at `pam_radius_auth.5`/`.8`, `radius_shell.8`.
+
+## Repository layout
+
+- `src/` — module source.
+- `pam_radius_auth.conf`, `pam_radius_auth.5`/`.8` — config + manpages.
+- `pamsymbols.ver` — symbol export map.
+- `debian/`, `pam_radius_auth.spec` — Debian and RPM packaging.
+- `Jenkinsfile` — legacy upstream CI (not used by VyOS pipeline).
+
+## Cross-repo context
+
+Authentication building block consumed by the VyOS image. Built by `VyOS-Networks/vyos-build-packages` and pulled into the ISO via `vyos/vyos-build`. Sibling auth repos: `libpam-tacplus`, `libnss-tacplus`, `libnss-mapuser`, `libtacplus-map`. Used by `vyos-1x` conf-mode scripts that wire `pam_radius` into `/etc/pam.d`.
+
+## Conventions
+
+- Default branch `current`; LTS branches `sagitta`/`circinus` when used.
+- Commit / PR title format: `component: T12345: description` (Phorge task ID at https://vyos.dev).
+- Treat as upstream-vendored: keep diffs against the original `pam_radius` minimal; large feature work goes in VyOS-specific glue rather than this fork.
+
+## Mirror relationship
+
+Mirror twin: `VyOS-Networks/libpam-radius-auth`. Canonical side is here. Active workflows: `cla-check.yml`, `pr-mirror-repo-sync.yml` — mirror pipeline IS wired up; merges to `current` propagate to the VyOS-Networks twin.
+
+## Notes for future contributors
+
+- Renamed source/binary packages (`vyos-libpam-radius-auth`, `vyos-radius-shell`) on purpose — do not revert to upstream `libpam-radius-auth` package names without a coordinated change in `vyos-build-packages` and `vyos-1x` PAM templates.
+- The `Jenkinsfile` is upstream cruft; VyOS CI runs through GitHub Actions reusables in `vyos/.github`.
+
+---
+
+This file is mirrored on Confluence: [`vyos/libpam-radius-auth`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818479352). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
