### PR TITLE
T8852: migrate .github/mergify.yml to extends: mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,25 +1,20 @@
-pull_request_rules:
-  - name: Label conflicting pull requests
-    description: Add a label to a pull request with conflict to spot it easily
-    conditions:
-      - conflict
-      - '-closed'
-    actions:
-      label:
-        toggle:
-          - conflicts
+# yaml-language-server: $schema=https://docs.mergify.com/configuration/file-format/
+# Mergify configuration for vyos/libpam-radius-auth.
+#
+# Inherits the central baseline from vyos/mergify:.mergify.yml. The central
+# baseline provides:
+#   - `defaults.actions.backport.ignore_conflicts: false`
+#   - `pull_request_rules` → label conflicting PRs with `conflicts`;
+#     T-ID format checks on PR title and commit messages.
+#   - `commands_restrictions` → restrict @Mergifyio slash commands to the
+#     org Maintainers team + vyosbot. Resolves correctly on both sides of
+#     the cross-org mirror: vyos/mergify uses @vyos/maintainers,
+#     VyOS-Networks/mergify uses @VyOS-Networks/maintainers.
+#
+# Replaces the inline T8531 predecessor config. Rollout context:
+# T8782 (Mergify central-config rollout), T8852 (fleet migration to
+# `extends:`). See https://vyos.dev/T8782, https://vyos.dev/T8852,
+# and the Confluence spec at
+# https://vyos.atlassian.net/wiki/spaces/VYOS/pages/849477640.
 
-commands_restrictions:
-  backport: &allowed
-    conditions:
-      - or:
-        - sender=@vyos/maintainers
-        - sender=vyosbot
-  copy: *allowed
-  dequeue: *allowed
-  queue: *allowed
-  rebase: *allowed
-  refresh: *allowed
-  requeue: *allowed
-  squash: *allowed
-  update: *allowed
+extends: mergify


### PR DESCRIPTION
## Change Summary

Replace the inline T8531 predecessor Mergify config in `.github/mergify.yml` with `extends: mergify`, deferring to the per-org central baseline ([vyos/mergify](https://github.com/vyos/mergify) on the vyos side, [VyOS-Networks/mergify](https://github.com/VyOS-Networks/mergify) on the mirror).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8852 — Mergify `extends:` fleet migration
* https://vyos.dev/T8782 — central-config rollout (precedent)

## Related PR(s)

* Precedent for the `extends:` template: [vyos/vyos-documentation/.github/mergify.yml](https://github.com/vyos/vyos-documentation/blob/rolling/.github/mergify.yml).
* Sibling fleet PR (vyatta-cfg): [vyos/vyatta-cfg#134](https://github.com/vyos/vyatta-cfg/pull/134).

## Component(s) name

CI / Mergify configuration

## Proposed changes

Old `.github/mergify.yml` inlined two stanzas verbatim from the T8531 predecessor rollout:

- `pull_request_rules` — label conflicting PRs with `conflicts`.
- `commands_restrictions` — restrict @Mergifyio slash commands to `@vyos/maintainers` + `vyosbot`.

Both stanzas now live in the per-org central baseline at [vyos/mergify:.mergify.yml](https://github.com/vyos/mergify/blob/production/.mergify.yml) and [VyOS-Networks/mergify:.mergify.yml](https://github.com/VyOS-Networks/mergify/blob/production/.mergify.yml). The central baseline also adds:

- `defaults.actions.backport.ignore_conflicts: false`
- T-ID format rules for PR title and commit message headlines (`invalid-title` label)

This PR replaces the inline content with a single `extends: mergify` directive. Per Mergify `extends:` semantics, `mergify` is resolved within the same org — so:

- On `vyos/libpam-radius-auth` → resolves to `vyos/mergify` (uses `@vyos/maintainers`)
- Mirror-propagated to `VyOS-Networks/libpam-radius-auth` (if applicable) → resolves to `VyOS-Networks/mergify` (uses `@VyOS-Networks/maintainers`)

## How to test

After merge, a Maintainer can comment `@Mergifyio backport <branch>` on a merged PR. Mergify should accept the command and create the backport PR. Pre-merge, Mergify itself surfaces config errors as PR comments if the YAML is malformed.

## Smoketest result

N/A — CI/Mergify-only change.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

## Backport

If the repo carries this file on `circinus` and `sagitta` branches as well, backport via `@Mergifyio backport circinus sagitta` after merge.

🤖 Generated by [robots](https://vyos.io)